### PR TITLE
Fix template for target type units

### DIFF
--- a/templates/systemd.unit.j2
+++ b/templates/systemd.unit.j2
@@ -8,10 +8,12 @@
 {% endfor %}
 {% endif %}
 
+{% if config.type|default(_default_unit_type)|title in config %}
 [{{ config.type|default(_default_unit_type)|title }}]
 {% for key, value in config[config.type|default(_default_unit_type)|title].items() %}
 {{ key }}={{ value }}
 {% endfor %}
+{% endif %}
 
 {% if "Install" in config %}
 [Install]


### PR DESCRIPTION
The template was not working for units of `type: target`. Now there is a check if the key in the configuration exists before accessing it.

Fixes #26 