### PR TITLE
Avoid iterating too much on items

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,5 @@
 ---
 - name: Include common config tasks
   include_tasks: "common/config.yml"
-  with_items: "{{ unit_config }}"
   tags:
     - config


### PR DESCRIPTION
This patch fixes an issue causing too much iterations on the unit items.

The units were iterated over twice, in: `tasks/main.yml` and in
`tasks/common/config.yml`.
Keep only the second loop.