### PR TITLE
Reload handler: Only restart modified units

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,8 +3,11 @@
   become: true
   systemd:
     name: "{{ restart_item.dest | basename }}"
-    state: "restarted"
+    state: "{{ 'restarted' if unit_requested_state == 'started' else unit_requested_state }}"
     daemon_reload: true
+  vars:
+    unit_requested_state: "{{ restart_item.unit_item.state | default(_default_unit_state) }}"
+  when: restart_item.changed
   with_items: "{{ restart_units.results }}"
   loop_control:
     loop_var: restart_item

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -1,4 +1,8 @@
 ---
+
+- name: Force the reload of the modified systemd units
+  meta: flush_handlers
+
 - name: Activate configured Systemd units
   become: true
   when: unit_config is defined and unit_config|length > 0


### PR DESCRIPTION
Without this patch the *reload* handler restarts every unit as soon as
at least one has been changed.
Additionally the reload handler is not executed before the activation
of the units, which is an issue when a unit has been modified (vs
created).

With this patch:
- handlers are called before activating units
- only units that have been modified are considered by the reload
  handler
- the reload handler only restarts units that are supposed to be
  started or restarted (we don't want to restart a unit that is
  requested to be stopped).