### PR TITLE
Add support for drop-in override configuration

### DIFF
--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -1,10 +1,11 @@
 ---
 - name: Create unit configuration path
+  become: true
+  when: unit_item.path is defined
   file:
     path: "{{ unit_item.path }}"
     state: directory
     mode: 0755
-  when: unit_item.path is defined
   with_items: "{{ unit_config }}"
   loop_control:
     loop_var: unit_item

--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -1,4 +1,16 @@
 ---
+- name: Create unit configuration path
+  file:
+    path: "{{ unit_item.path }}"
+    state: directory
+    mode: 0755
+  when: unit_item.path is defined
+  with_items: "{{ unit_config }}"
+  loop_control:
+    loop_var: unit_item
+  tags:
+    - config
+
 - name: Render unit configuration
   become: true
   when: unit_config is defined and unit_config|length > 0

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -5,7 +5,7 @@
 
 - name: Activate configured Systemd units
   become: true
-  when: unit_config is defined and unit_config|length > 0
+  when: unit_config is defined and unit_config|length > 0 and unit_item.type is not defined or unit_item.type != 'conf'
   systemd:
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: "{{ unit_item.state | default(_default_unit_state) }}"

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -5,7 +5,7 @@
 
 - name: Activate configured Systemd units
   become: true
-  when: unit_config is defined and unit_config|length > 0 and unit_item.type is not defined or unit_item.type != 'conf'
+  when: unit_config is defined and unit_config|length > 0 and (unit_item.type is not defined or unit_item.type != 'conf')
   systemd:
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: "{{ unit_item.state | default(_default_unit_state) }}"

--- a/templates/systemd.unit.j2
+++ b/templates/systemd.unit.j2
@@ -4,6 +4,9 @@
 {% if "Unit" in config %}
 [Unit]
 {% for key, value in config["Unit"].items() %}
+{% if config.type is defined and config.type == "conf" %}
+{{ key }}=
+{% endif %}
 {{ key }}={{ value }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Add support for override configuration files.

Example vars:
```
  # Override example service to trigger additional.service restart
  - name: 'override'
    path: /etc/systemd/system/example.service.d
    type: 'conf'
    Unit:
      PartOf: 'existing.service additional.service'
```