### PR TITLE
Add label to loop_control in handlers and replace with_items with loop

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,9 +8,10 @@
   vars:
     unit_requested_state: "{{ restart_item.unit_item.state | default(_default_unit_state) }}"
   when: restart_item.changed
-  with_items: "{{ restart_units.results }}"
+  loop: "{{ restart_units.results }}"
   loop_control:
     loop_var: restart_item
+    label: "{{ restart_item.unit_item.name }}.{{ restart_item.unit_item.type | default(_default_unit_type) }}"
   listen: "Reload systemd units"
   ignore_errors: true
 
@@ -20,9 +21,10 @@
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: "stopped"
     enabled: "no"
-  with_items: "{{ unit_config }}"
+  loop: "{{ unit_config }}"
   loop_control:
     loop_var: unit_item
+    label: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
   listen: Uninstall units
   ignore_errors: true
 
@@ -32,6 +34,7 @@
     path: "{{ unit_item.path | default(_default_unit_path) }}/{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: absent
   listen: Uninstall units
-  with_items: "{{ unit_config }}"
+  loop: "{{ unit_config }}"
   loop_control:
     loop_var: unit_item
+    label: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"

--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -6,9 +6,10 @@
     path: "{{ unit_item.path }}"
     state: directory
     mode: 0755
-  with_items: "{{ unit_config }}"
+  loop: "{{ unit_config }}"
   loop_control:
     loop_var: unit_item
+    label: "{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"
   tags:
     - config
 
@@ -25,7 +26,7 @@
   vars:
     config: "{{ unit_item }}"
   register: "restart_units"
-  with_items: "{{ unit_config }}"
+  loop: "{{ unit_config }}"
   loop_control:
     loop_var: unit_item
     label: "{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -10,7 +10,7 @@
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: "{{ unit_item.state | default(_default_unit_state) }}"
     enabled: "{{ unit_item.enabled | default(_default_unit_enabled) }}"
-  with_items: "{{ unit_config }}"
+  loop: "{{ unit_config }}"
   loop_control:
     loop_var: unit_item
     label: "{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"


### PR DESCRIPTION
- Add loop_label to new handlers
- Replace with_items to loop. In [ansible doc](https://docs.ansible.com/ansible/latest/user_guide/playbooks_loops.html#with-items) this replacing shown as `loop: "{{ items|flatten(levels=1) }}"`, but i think in this case flatten filter is overhead