### PR TITLE
Fix drop in unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ Provides override capabilities for units.
       path: "/lib/systemd/system/getty@.service.d"
       Service:
         ExecStart:
-          type: override
-          value: -/sbin/agetty -a muru --noclear %I $TERM
+          - ""
+          - "-/sbin/agetty -a muru --noclear %I $TERM"
         EnvironmentFile=/path/to/some/file
 ```
 

--- a/README.md
+++ b/README.md
@@ -330,6 +330,24 @@ The name of the slice encodes the location in the tree. The name consists of a d
 
 See [systemd.slice(5)](http://man7.org/linux/man-pages/man5/systemd.slice.5.html) for more details.
 
+**[[Drop-in](http://man7.org/linux/man-pages/man1/systemd.1.html)]**
+
+Provides override capabilities for units.
+
+#### Example
+
+ ```yaml
+  unit_config:
+    - name: override.conf
+      type: conf
+      path: "/lib/systemd/system/getty@.service.d"
+      Service:
+        ExecStart:
+          type: override
+          value: -/sbin/agetty -a muru --noclear %I $TERM
+        EnvironmentFile=/path/to/some/file
+```
+
 #### Launch
 
 `[unit_config: <config-list-entry>:] enabled:` (**default**: <string> `no`)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,6 +15,18 @@
   listen: "Reload systemd units"
   ignore_errors: true
 
+- name: Reload systemd daemon
+  become: true
+  systemd:
+    daemon_reload: true
+  when: restart_item.changed
+  loop: "{{ restart_override_units.results }}"
+  loop_control:
+    loop_var: restart_item
+    label: "{{ restart_item.unit_item.name }}.{{ restart_item.unit_item.type | default(_default_unit_type) }}"
+  listen: "Reload systemd daemon"
+  ignore_errors: true
+
 - name: Uninstall systemd units
   become: true
   systemd:

--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -15,7 +15,8 @@
 
 - name: Render unit configuration
   become: true
-  when: unit_config is defined and unit_config|length > 0
+  when: unit_config is defined and unit_config|length > 0 and
+    unit_item.type|default(_default_unit_type) != "conf"
   template:
     src: "systemd.unit.j2"
     dest: "{{ unit_item.path|default(_default_unit_path) }}/{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"
@@ -31,5 +32,27 @@
     loop_var: unit_item
     label: "{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"
   notify: Reload systemd units
+  tags:
+    - config
+
+- name: Render override unit configuration
+  become: true
+  when: unit_config is defined and unit_config|length > 0 and
+    unit_item.type|default(_default_unit_type) == "conf"
+  template:
+    src: "override.conf.j2"
+    dest: "{{ unit_item.path|default(_default_unit_path) }}/{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"
+    owner: "root"
+    group: "root"
+    mode: 0644
+    backup: true
+  vars:
+    config: "{{ unit_item }}"
+  register: "restart_override_units"
+  loop: "{{ unit_config }}"
+  loop_control:
+    loop_var: unit_item
+    label: "{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"
+  notify: Reload systemd daemon
   tags:
     - config

--- a/templates/override.conf.j2
+++ b/templates/override.conf.j2
@@ -3,22 +3,13 @@
 
 {% for section in config.keys() if section == section|title  %}
 [{{ section }}]
-{%- for key, value in config[section].items() %}
-
-{% if value is mapping -%}
-
-{% if "type" in value and value["type"]=="override" %}
-{{ key }}=
-{% endif %}
-{% if "value" in value %}
-{{ key }}={{ value["value"] }}
-{%- endif -%}
-
-{%- else -%}
-
+{% for key, value in config[section].items() %}
+{% if (value is not mapping) and (value is iterable) and (value is not string) %}
+{% for item in value %}
+{{ key }}={{ item }}
+{% endfor %}
+{% else %}
 {{ key }}={{ value }}
-
-{%- endif -%}
-
+{% endif %}
 {% endfor %}
 {% endfor %}

--- a/templates/override.conf.j2
+++ b/templates/override.conf.j2
@@ -1,0 +1,24 @@
+{{ ansible_managed | comment }}
+# see: Systemd Unit configuration logic -- http://man7.org/linux/man-pages/man5/systemd.unit.5.html for more details
+
+{% for section in config.keys() if section == section|title  %}
+[{{ section }}]
+{%- for key, value in config[section].items() %}
+
+{% if value is mapping -%}
+
+{% if "type" in value and value["type"]=="override" %}
+{{ key }}=
+{% endif %}
+{% if "value" in value %}
+{{ key }}={{ value["value"] }}
+{%- endif -%}
+
+{%- else -%}
+
+{{ key }}={{ value }}
+
+{%- endif -%}
+
+{% endfor %}
+{% endfor %}

--- a/templates/systemd.unit.j2
+++ b/templates/systemd.unit.j2
@@ -4,9 +4,6 @@
 {% if "Unit" in config %}
 [Unit]
 {% for key, value in config["Unit"].items() %}
-{% if config.type is defined and config.type == "conf" %}
-{{ key }}=
-{% endif %}
 {{ key }}={{ value }}
 {% endfor %}
 {% endif %}

--- a/test/integration/config/config_unit/default_playbook.yml
+++ b/test/integration/config/config_unit/default_playbook.yml
@@ -49,5 +49,5 @@
             path: "/lib/systemd/system/getty@.service.d"
             Service:
               ExecStart:
-                type: override
-                value: -/sbin/agetty -a muru --noclear %I $TERM
+                - ""
+                - "-/sbin/agetty -a muru --noclear %I $TERM"

--- a/test/integration/config/config_unit/default_playbook.yml
+++ b/test/integration/config/config_unit/default_playbook.yml
@@ -44,3 +44,10 @@
               Description: This is an example unit Target
               Wants: test-service.service test-service.socket tmp-stdin.mount
               PartOf: test-service.service
+          - name: "test-drop-in"
+            type: "conf"
+            path: "/lib/systemd/system/getty@.service.d"
+            Service:
+              ExecStart:
+                type: override
+                value: -/sbin/agetty -a muru --noclear %I $TERM


### PR DESCRIPTION
This PR tries to fix some issues when using `type conf` or drop-in units, namely:

- Couldn't override anything other than section `[Unit]`
- Parameters were always overridden:
```
parameter=
parameter=<new value>
```
- systemd was not reloaded after new drop-in configuration file

Also, README.md and a test case were added.