### PR TITLE
Add possibility to use list to add multiple entries of the same name

### DIFF
--- a/templates/systemd.unit.j2
+++ b/templates/systemd.unit.j2
@@ -4,23 +4,38 @@
 {% if "Unit" in config %}
 [Unit]
 {% for key, value in config["Unit"].items() %}
-{% if config.type is defined and config.type == "conf" %}
-{{ key }}=
-{% endif %}
+{% if (value is not mapping) and (value is iterable) and (value is not string) %}
+{% for item in value %}
+{{ key }}={{ item }}
+{% endfor %}
+{% else %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}
 {% endif %}
 
 {% if config.type|default(_default_unit_type)|title in config %}
 [{{ config.type|default(_default_unit_type)|title }}]
 {% for key, value in config[config.type|default(_default_unit_type)|title].items() %}
+{% if (value is not mapping) and (value is iterable) and (value is not string) %}
+{% for item in value %}
+{{ key }}={{ item }}
+{% endfor %}
+{% else %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}
 {% endif %}
 
 {% if "Install" in config %}
 [Install]
 {% for key, value in config["Install"].items() %}
+{% if (value is not mapping) and (value is iterable) and (value is not string) %}
+{% for item in value %}
+{{ key }}={{ item }}
+{% endfor %}
+{% else %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}
 {% endif %}

--- a/test/integration/config/config_unit/default_playbook.yml
+++ b/test/integration/config/config_unit/default_playbook.yml
@@ -18,6 +18,22 @@
               ExecReload: '/bin/kill -s HUP $MAINPID'
             Install:
               WantedBy: 'multi-user.target'
+          - name: "test-multiple-items"
+            Unit:
+              Description: "This is a test service unit which listens at port 1234"
+              After: network-online.target
+              Wants: network-online.target
+              Requires: test-service.socket
+            Service:
+              Environment:
+                - "VAR1=1"
+                - "VAR2=2"
+              User: 'kitchen'
+              Group: 'kitchen'
+              ExecStart: '/usr/bin/sleep infinity'
+              ExecReload: '/bin/kill -s HUP $MAINPID'
+            Install:
+              WantedBy: 'multi-user.target'
           - name: "test-service"
             type: "socket"
             Unit:


### PR DESCRIPTION
This is useful in systemd properties that uses the name multiple times to append, like "Environment".