### PR TITLE
Add reload_on_change option

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,7 +7,8 @@
     daemon_reload: true
   vars:
     unit_requested_state: "{{ restart_item.unit_item.state | default(_default_unit_state) }}"
-  when: restart_item.changed
+  when:
+    - restart_item.changed and (restart_item.unit_item.reload_on_change is not defined or restart_item.unit_item.reload_on_change)
   loop: "{{ restart_units.results }}"
   loop_control:
     loop_var: restart_item


### PR DESCRIPTION
Add support to disable reloading of systemd untis if they change during deployment

`reload_on_change: false`