### PR TITLE
Dont create backupfiles by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 _default_unit_path: "/etc/systemd/system"
 _default_unit_type: "service"
 _default_unit_enabled: "no"
+_default_systemd_backup_files: true
 _default_unit_state: "stopped"
 
 unit_config: []

--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -45,7 +45,7 @@
     owner: "root"
     group: "root"
     mode: 0644
-    backup: backup: "{{ systemd_backup_files | default(_default_systemd_backup_files) }}"
+    backup: "{{ systemd_backup_files | default(_default_systemd_backup_files) }}"
   vars:
     config: "{{ unit_item }}"
   register: "restart_override_units"

--- a/tasks/common/config.yml
+++ b/tasks/common/config.yml
@@ -23,7 +23,7 @@
     owner: "root"
     group: "root"
     mode: 0644
-    backup: true
+    backup: "{{ systemd_backup_files | default(_default_systemd_backup_files) }}"
   vars:
     config: "{{ unit_item }}"
   register: "restart_units"
@@ -45,7 +45,7 @@
     owner: "root"
     group: "root"
     mode: 0644
-    backup: true
+    backup: backup: "{{ systemd_backup_files | default(_default_systemd_backup_files) }}"
   vars:
     config: "{{ unit_item }}"
   register: "restart_override_units"


### PR DESCRIPTION
This PR simply makes creating the backupfiles by ansible optionally, but by default is turned on.
I was simply annoyed by those backupfiles, as i dont need them.
 