### PR TITLE
Systemd stops service when started by timer

### DIFF
--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -6,9 +6,11 @@
 - name: Activate configured Systemd units
   become: true
   when: unit_config is defined and unit_config|length > 0 and (unit_item.type is not defined or unit_item.type != 'conf')
+  vars:
+    unit_item_manage_state: "{{ true if unit_item.manage_state is not defined or unit_item.manage_state else false }}"
   systemd:
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
-    state: "{{ unit_item.state | default(_default_unit_state) }}"
+    state: "{{ unit_item.state | default(_default_unit_state) if unit_item_manage_state else omit }}"
     enabled: "{{ unit_item.enabled | default(_default_unit_enabled) }}"
   loop: "{{ unit_config }}"
   loop_control:


### PR DESCRIPTION
This PR fixes an issue when this role is executed and any `systemd` `service` `unit` is currently running (i.e. state `started`). When the role updates its definitions of `systemd` unit files, it ensures that the running state conforms to the value of `unit_item.state` or `_default_unit_state`. This is done in the task titled "Activate configured Systemd units".

Since it is started by a `systemd` `timer` and according to the role, it is *not* supposed to be enabled, hence the service is shutdown. This could happen to any service `unit` that is supposed to be in a `stopped` state. This "anomaly" I would like to address in this PR.

When you do not want the role to enforce the state of the service (`stopped`, `started`), simply by adding the variable `unit_item.manage_state` it tells the roles systemd task to either manage the state, or simple omitting the state setting.

```yaml
unit_config:
  - name: "Test Service"
    manage_state: false
    Unit:
      Description: Service Test
    Service:
      User: test_user
      Group: test_user
      ExecStart: /usr/bin/ls /etc/fstab
    Install:
      WantedBy: multi-user.target
  - name: "Test Timer"
    type: timer
    enabled: true
    state: started
    Unit:
      Description: Timer Test
    Timer:
      OnCalendar: "*-*-* 4:00:00"
      Unit: "test_service.service"
    Install:
      WantedBy: timers.target
```

This configuration will create a unit with a `state` that will not be managed by this role since the `manage_state` is set to false.

We could name the variable `enforce_state` instead of `manage_state`.

Fixes #53