### PR TITLE
ignore errors if check-mode is on

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -14,7 +14,7 @@
     loop_var: restart_item
     label: "{{ restart_item.unit_item.name }}.{{ restart_item.unit_item.type | default(_default_unit_type) }}"
   listen: "Reload systemd units"
-  ignore_errors: true
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Reload systemd daemon
   become: true

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -16,3 +16,4 @@
     label: "{{ unit_item.name }}.{{ unit_item.type|default(_default_unit_type) }}"
   tags:
     - launch
+  ignore_errors: "{{ ansible_check_mode }}"


### PR DESCRIPTION
When this role is run using check-mode, no files are created, so nothing can be restarted or activated.
This small change just ignores errors if check_mode is running.