### PR TITLE
do not reload or activate when creating template

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,7 +9,7 @@
     unit_requested_state: "{{ restart_item.unit_item.state | default(_default_unit_state) }}"
   when:
     - restart_item.changed and (restart_item.unit_item.reload_on_change is not defined or restart_item.unit_item.reload_on_change) and
-      (not restart_item.unit_item.name | search("^[^@]+@$"))
+      (restart_item.unit_item.name is not search("^[^@]+@$"))
   loop: "{{ restart_units.results }}"
   loop_control:
     loop_var: restart_item

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -8,7 +8,8 @@
   vars:
     unit_requested_state: "{{ restart_item.unit_item.state | default(_default_unit_state) }}"
   when:
-    - restart_item.changed and (restart_item.unit_item.reload_on_change is not defined or restart_item.unit_item.reload_on_change)
+    - restart_item.changed and (restart_item.unit_item.reload_on_change is not defined or restart_item.unit_item.reload_on_change) and
+      (not restart_item.unit_item.name | search("^[^@]+@$"))
   loop: "{{ restart_units.results }}"
   loop_control:
     loop_var: restart_item

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -5,7 +5,8 @@
 
 - name: Activate configured Systemd units
   become: true
-  when: unit_config is defined and unit_config|length > 0 and (unit_item.type is not defined or unit_item.type != 'conf')
+  when: unit_config is defined and unit_config|length > 0 and (unit_item.type is not defined or unit_item.type != 'conf') and
+        (not unit_item.name | search("^[^@]+@$"))
   systemd:
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: "{{ unit_item.state | default(_default_unit_state) }}"

--- a/tasks/common/launch.yml
+++ b/tasks/common/launch.yml
@@ -6,7 +6,7 @@
 - name: Activate configured Systemd units
   become: true
   when: unit_config is defined and unit_config|length > 0 and (unit_item.type is not defined or unit_item.type != 'conf') and
-        (not unit_item.name | search("^[^@]+@$"))
+        (unit_item.name is not search("^[^@]+@$"))
   systemd:
     name: "{{ unit_item.name }}.{{ unit_item.type | default(_default_unit_type) }}"
     state: "{{ unit_item.state | default(_default_unit_state) }}"


### PR DESCRIPTION
This will hopefully fix https://github.com/0x0I/ansible-role-systemd/issues/48

The regex matches the `name` attribute of the `unit_item` if it does not have an instance name after the `@`.
Say:
`test@` matches.
`test@test` does not match.


(This does also not match if you do something like this: `test@test@`. I dont know why systemd allows `@` in instance names....)