### PR TITLE
Support multiple values in the key

### DIFF
--- a/templates/systemd.unit.j2
+++ b/templates/systemd.unit.j2
@@ -11,7 +11,13 @@
 {% if config.type|default(_default_unit_type)|title in config %}
 [{{ config.type|default(_default_unit_type)|title }}]
 {% for key, value in config[config.type|default(_default_unit_type)|title].items() %}
+{% if value is not string and value is iterable %}
+{% for value_item in value %}
+{{ key }}={{ value_item }}
+{% endfor %}
+{% else %}
 {{ key }}={{ value }}
+{% endif %}
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
Closes #64

This PR is an addition to the feature #64.

It allows multiple lines of the same key, different values, to be defined in unit files.

```yaml
unit_config:
  - name: "test-service"
    type: service
    Unit:
      Description: This is test service
    Service:
      Type: simple
      Environment:
        - "ENV1=foo"
        - "ENV2=bar"
        - "ENV3=baz"
      ExecStartPre:
        - "/path/to/pre1"
        - "/path/to/pre2"
      ExecStart: "/path/to/start"
    Install:
      WantedBy: multi-user.target
```