### PR TITLE
flush_handlers task does not support when conditional

### DIFF
--- a/tasks/common/preflight.yml
+++ b/tasks/common/preflight.yml
@@ -1,12 +1,10 @@
 ---
 - name: Check for uninstall signal
+  command: /bin/true
+  notify: Uninstall units
   when: perform_uninstall|bool
-  block:
-    - name: Broadcast uninstall signal
-      command: /bin/true
-      notify: Uninstall units
-  always:
-    - name: Flush handlers
-      meta: flush_handlers
   tags:
     - preflight
+
+- name: Flush handlers
+  meta: flush_handlers

--- a/tasks/common/preflight.yml
+++ b/tasks/common/preflight.yml
@@ -3,14 +3,6 @@
   command: /bin/true
   notify: Uninstall units
   when: perform_uninstall|bool
-  block:
-    - name: Broadcast uninstall signal
-      command: /bin/true
-      notify: Uninstall units
-      changed_when: false
-  always:
-    - name: Flush handlers
-      meta: flush_handlers
   tags:
     - preflight
 


### PR DESCRIPTION
Hi! Since flush_handlers tasks does not supported when conditional i made a small adjustments.
This commit resolves warning:

```
TASK [0x0i.systemd : Flush handlers] *******************************************
[WARNING]: flush_handlers task does not support when conditional
```

Ansible github issues 41313, 77616