### PR TITLE
chore: add semantic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: go-semantic-release/action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          allow-initial-development-versions: true


### PR DESCRIPTION
## Summary
- Add `Create Release` GitHub Actions workflow using `go-semantic-release`
- Runs weekly (Mondays at midnight UTC) and supports manual dispatch
- Enables automated versioning from conventional commits

## Test plan
- [ ] Merge and run workflow via **Actions → Create Release → Run workflow**
- [ ] Confirm release/tag is created when eligible commits exist

Made with [Cursor](https://cursor.com)